### PR TITLE
Added support for requesting serverAuthCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ func _on_sign_in_success(userProfile_json: String) -> void:
 		userProfile["displayName"] # The user's display name
 		userProfile["email"] # The user's email
 		userProfile["token"] # User token for backend use
+		userProfile["authCode"] # ServerAuthCode one-time token to enable server-side access (like Firebase Auth)
 		userProfile["id"] # The user's id
 
 func _on_sign_in_failed(error_code: int) -> void:

--- a/app/src/main/java/io/cgisca/godot/gpgs/ConnectionController.kt
+++ b/app/src/main/java/io/cgisca/godot/gpgs/ConnectionController.kt
@@ -13,7 +13,7 @@ class ConnectionController(
 ) {
 
     fun isConnected(): Pair<Boolean, UserProfile> {
-        val userProfile = UserProfile(null, null, null, null)
+        val userProfile = UserProfile(null, null, null, null, null)
         val googleSignInAccount = GoogleSignIn.getLastSignedInAccount(activity)
             ?: return Pair(false, userProfile)
 
@@ -23,6 +23,7 @@ class ConnectionController(
                 it.displayName = googleSignInAccount.displayName
                 it.email = googleSignInAccount.email
                 it.token = googleSignInAccount.idToken
+                it.authCode = googleSignInAccount.serverAuthCode
                 it.id = googleSignInAccount.id
             }
             return Pair(GoogleSignIn.hasPermissions(googleSignInAccount, *signInOptions.scopeArray), userProfile)

--- a/app/src/main/java/io/cgisca/godot/gpgs/PlayGameServicesGodot.kt
+++ b/app/src/main/java/io/cgisca/godot/gpgs/PlayGameServicesGodot.kt
@@ -199,6 +199,7 @@ class PlayGameServicesGodot(godot: Godot) : GodotPlugin(godot), AchievementsList
                 signInOptionsBuilder.requestScopes(Scope(Scopes.DRIVE_APPFOLDER))
             if (requestToken.isNotEmpty()) {
                 signInOptionsBuilder.requestIdToken(requestToken)
+                signInOptionsBuilder.requestServerAuthCode(requestToken)
             }
             if (requestEmail)
                 signInOptionsBuilder.requestEmail()

--- a/app/src/main/java/io/cgisca/godot/gpgs/signin/SignInController.kt
+++ b/app/src/main/java/io/cgisca/godot/gpgs/signin/SignInController.kt
@@ -26,7 +26,7 @@ class SignInController(
     }
 
     fun signIn(googleSignInClient: GoogleSignInClient) {
-        val userProfile = UserProfile(null, null, null, null)
+        val userProfile = UserProfile(null, null, null, null, null)
         val connection: Pair<Boolean, UserProfile> = connectionController.isConnected()
         if (connection.first) {
             Log.i("godot","Using cached signin data")
@@ -44,6 +44,7 @@ class SignInController(
                                 it.displayName = googleSignInAccount.displayName
                                 it.email = googleSignInAccount.email
                                 it.token = googleSignInAccount.idToken
+                                it.authCode = googleSignInAccount.serverAuthCode
                                 it.id = googleSignInAccount.id
                             }
                         }
@@ -59,7 +60,7 @@ class SignInController(
     }
 
     fun onSignInActivityResult(googleSignInResult: GoogleSignInResult?) {
-        val userProfile = UserProfile(null, null, null, null)
+        val userProfile = UserProfile(null, null, null, null, null)
         if (googleSignInResult != null && googleSignInResult.isSuccess) {
             val googleSignInAccount = googleSignInResult.signInAccount
             if (googleSignInAccount != null) {
@@ -67,6 +68,7 @@ class SignInController(
                     it.displayName = googleSignInAccount.displayName
                     it.email = googleSignInAccount.email
                     it.token = googleSignInAccount.idToken
+                    it.authCode = googleSignInAccount.serverAuthCode
                     it.id = googleSignInAccount.id
                 }
             }

--- a/app/src/main/java/io/cgisca/godot/gpgs/signin/UserProfile.kt
+++ b/app/src/main/java/io/cgisca/godot/gpgs/signin/UserProfile.kt
@@ -1,4 +1,9 @@
 package io.cgisca.godot.gpgs.signin
 
-data class UserProfile(var displayName: String?, var email: String?, var token: String?, var id: String?) {
+data class UserProfile(
+    var displayName: String?,
+    var email: String?,
+    var token: String?,
+    var authCode: String?,
+    var id: String?) {
 }


### PR DESCRIPTION
Added support to request `serverAuthCode` during login, necessary for server-side access services like Firebase Auth with Game Services provider.

https://developers.google.com/games/services/v1/android/offline-access
https://firebase.google.com/docs/auth/android/play-games
